### PR TITLE
Update to newer dependency

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -6,6 +6,6 @@
   "license": "MIT",
   "dependencies": {
     "dunit": "~>1.0.12",
-    "std_data_json": "~>0.17.0"
+    "std_data_json": "~>0.18.0"
   }
 }


### PR DESCRIPTION
Update to a newer library version which doesn't have a bunch of deprecation and such. Fixes issue #2.

Note that DMD 2.072 has a bug causing unittest failures in windows: https://issues.dlang.org/show_bug.cgi?id=16696

This bug is resolved in 2.072.1 (currently going through beta).